### PR TITLE
fix: add checks on `ResultBroadcastTx` to avoid NPE + cleanup error handling code

### DIFF
--- a/cmd/ethereum/listener.go
+++ b/cmd/ethereum/listener.go
@@ -3,9 +3,12 @@ package ethereum
 import (
 	"bytes"
 	"context"
-	"cosmossdk.io/log"
 	"embed"
 	"fmt"
+	"math/big"
+	"os"
+
+	"cosmossdk.io/log"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -13,8 +16,6 @@ import (
 	"github.com/pascaldekloe/etherstream"
 	"github.com/strangelove-ventures/noble-cctp-relayer/config"
 	"github.com/strangelove-ventures/noble-cctp-relayer/types"
-	"math/big"
-	"os"
 )
 
 //go:embed abi/MessageTransmitter.json
@@ -66,7 +67,7 @@ func StartListener(cfg config.Config, logger log.Logger, processingQueue chan *t
 	for _, historicalLog := range history {
 		parsedMsg, err := types.EvmLogToMessageState(messageTransmitterABI, messageSent, &historicalLog)
 		if err != nil {
-			logger.Error("Unable to parse history log into MessageState, skipping")
+			logger.Error("Unable to parse history log into MessageState, skipping", "err", err)
 			continue
 		}
 		logger.Info(fmt.Sprintf("New historical msg from source domain %d with tx hash %s", parsedMsg.SourceDomain, parsedMsg.SourceTxHash))

--- a/cmd/noble/listener.go
+++ b/cmd/noble/listener.go
@@ -1,16 +1,17 @@
 package noble
 
 import (
-	"cosmossdk.io/log"
 	"encoding/json"
 	"fmt"
-	"github.com/strangelove-ventures/noble-cctp-relayer/config"
-	"github.com/strangelove-ventures/noble-cctp-relayer/types"
 	"io"
 	"net/http"
 	"strconv"
 	"sync"
 	"time"
+
+	"cosmossdk.io/log"
+	"github.com/strangelove-ventures/noble-cctp-relayer/config"
+	"github.com/strangelove-ventures/noble-cctp-relayer/types"
 )
 
 func StartListener(cfg config.Config, logger log.Logger, processingQueue chan *types.MessageState) {

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 )
 
 require (
+	cosmossdk.io/math v1.1.2
 	github.com/circlefin/noble-cctp v0.0.0-20230911222715-829029fbba29
 	github.com/cometbft/cometbft v0.38.0
 	github.com/gin-gonic/gin v1.8.1
@@ -30,7 +31,6 @@ require (
 	cosmossdk.io/api v0.3.1 // indirect
 	cosmossdk.io/core v0.5.1 // indirect
 	cosmossdk.io/depinject v1.0.0-alpha.4 // indirect
-	cosmossdk.io/math v1.1.2 // indirect
 	filippo.io/edwards25519 v1.0.0 // indirect
 	github.com/4meepo/tagalign v1.3.2 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect

--- a/types/message_state.go
+++ b/types/message_state.go
@@ -6,13 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
+	"time"
+
 	"github.com/circlefin/noble-cctp/x/cctp/types"
 	"github.com/cosmos/cosmos-sdk/types/bech32"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"strconv"
-	"time"
 )
 
 const (
@@ -45,7 +46,6 @@ type MessageState struct {
 
 // EvmLogToMessageState transforms an evm log into a messageState given an ABI
 func EvmLogToMessageState(abi abi.ABI, messageSent abi.Event, log *ethtypes.Log) (messageState *MessageState, err error) {
-
 	event := make(map[string]interface{})
 	_ = abi.UnpackIntoMap(event, messageSent.Name, log.Data)
 
@@ -80,7 +80,7 @@ func EvmLogToMessageState(abi abi.ABI, messageSent abi.Event, log *ethtypes.Log)
 		return messageState, nil
 	}
 
-	return nil, errors.New(fmt.Sprintf("unable to parse txn into message.  tx hash %s", log.TxHash.Hex()))
+	return nil, errors.New(fmt.Sprintf("unable to parse tx into message, tx hash %s", log.TxHash.Hex()))
 }
 
 // NobleLogToMessageState transforms a Noble log into a messageState


### PR DESCRIPTION
This PR adds an additional check on `ResultBroadcastTx`, which is returned by `BroadcastTxSync`, to ensure the result is not nil before attempting to log the response code and logs.

This also cleans up the error handling code to remove duplicate code and separates concerns into smaller functions for better readability and maintainability.

Closes #17 