### PR TITLE
Multiple destination domains

### DIFF
--- a/cmd/process.go
+++ b/cmd/process.go
@@ -48,7 +48,7 @@ func Start(cmd *cobra.Command, args []string) {
 		go c.StartListener(cmd.Context(), Logger, processingQueue)
 
 		if _, ok := registeredDomains[c.Domain()]; ok {
-			Logger.Error("Duplicate domain found", "domain", c.Domain())
+			Logger.Error("Duplicate domain found", "domain", c.Domain(), "name:", c.Name())
 			os.Exit(1)
 		}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	file, err := cmd.Parse("../config/sample.yaml")
+	file, err := cmd.Parse("../config/sample-config.yaml")
 	require.NoError(t, err, "Error parsing config")
 
 	// assert noble chainConfig correctly parsed

--- a/config/sample-config.yaml
+++ b/config/sample-config.yaml
@@ -32,8 +32,8 @@ chains:
 
 # source domain id -> destination domain id
 enabled-routes:
-  0: 4 # ethereum to noble
-  4: 0 # noble to ethereum
+  0: [4] # ethereum to noble
+  4: [0] # noble to ethereum
 
 circle:
   attestation-base-url: "https://iris-api-sandbox.circle.com/attestations/"

--- a/ethereum/chain.go
+++ b/ethereum/chain.go
@@ -53,6 +53,7 @@ func NewChain(
 	return &Ethereum{
 		name:                      name,
 		chainID:                   chainID,
+		domain:                    domain,
 		rpcURL:                    rpcURL,
 		wsURL:                     wsURL,
 		messageTransmitterAddress: messageTransmitterAddress,

--- a/ethereum/config.go
+++ b/ethereum/config.go
@@ -9,7 +9,7 @@ var _ types.ChainConfig = (*ChainConfig)(nil)
 type ChainConfig struct {
 	RPC                string `yaml:"rpc"`
 	WS                 string `yaml:"ws"`
-	domain             types.Domain
+	Domain             types.Domain
 	ChainID            int64  `yaml:"chain-id"`
 	MessageTransmitter string `yaml:"message-transmitter"`
 
@@ -26,7 +26,7 @@ type ChainConfig struct {
 func (c *ChainConfig) Chain(name string) (types.Chain, error) {
 	return NewChain(
 		name,
-		c.domain,
+		c.Domain,
 		c.ChainID,
 		c.RPC,
 		c.WS,

--- a/integration/config.go
+++ b/integration/config.go
@@ -49,7 +49,7 @@ func setupTestIntegration() func() {
 	}
 
 	nobleCfg = cfg.Chains["noble"].(*noble.ChainConfig)
-	ethCfg = cfg.Chains["ethereum"].(*ethereum.ChainConfig)
+	ethCfg = cfg.Chains["sepolia"].(*ethereum.ChainConfig)
 
 	sequenceMap = types.NewSequenceMap()
 

--- a/types/config.go
+++ b/types/config.go
@@ -2,7 +2,7 @@ package types
 
 type Config struct {
 	Chains        map[string]ChainConfig `yaml:"chains"`
-	EnabledRoutes map[Domain]Domain      `yaml:"enabled-routes"`
+	EnabledRoutes map[Domain][]Domain    `yaml:"enabled-routes"`
 	Circle        struct {
 		AttestationBaseUrl string `yaml:"attestation-base-url"`
 		FetchRetries       int    `yaml:"fetch-retries"`
@@ -16,7 +16,7 @@ type Config struct {
 
 type ConfigWrapper struct {
 	Chains        map[string]map[string]any `yaml:"chains"`
-	EnabledRoutes map[Domain]Domain         `yaml:"enabled-routes"`
+	EnabledRoutes map[Domain][]Domain       `yaml:"enabled-routes"`
 	Circle        struct {
 		AttestationBaseUrl string `yaml:"attestation-base-url"`
 		FetchRetries       int    `yaml:"fetch-retries"`


### PR DESCRIPTION
This PR allows `enabled-routes` to include multiple `destination-domains` for one `source-domain`.

Going from: 	
`EnabledRoutes map[Domain]Domain`


To:
`EnabledRoutes map[Domain][]Domain`