### PR TITLE
Refactor listener; add flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,16 @@ Running the relayer
 noble-cctp-relayer start --config ./config/sample-app-config.yaml
 ```
 Sample configs can be found in [config](config).
-### Promethius Metrics
+
+### Flush Interval
+
+Using the `--flush-interval` flag will run a flush on all paths every `duration`; ex `--flush-interval 5m`
+
+The relayer will keep track of the latest flushed block. The first time the flush is run, the flush will start at the chains latest height - lookback period and flush up until height of the chain when the flush started. It will then store the height the flush ended on.
+
+After that, it will flush from the last stored height - lookback period up until the latest height of the chain.
+
+### Prometheus Metrics
 
 By default, metrics are exported at on port :2112/metrics (`http://localhost:2112/metrics`). You can customize the port using the `--metrics-port` flag. 
 

--- a/cmd/appstate.go
+++ b/cmd/appstate.go
@@ -63,10 +63,10 @@ func (a *AppState) loadConfigFile() {
 	}
 	config, err := ParseConfig(a.ConfigPath)
 	if err != nil {
-		a.Logger.Error("unable to parse config file", "location", a.ConfigPath, "err", err)
+		a.Logger.Error("Unable to parse config file", "location", a.ConfigPath, "err", err)
 		os.Exit(1)
 	}
-	a.Logger.Info("successfully parsed config file", "location", a.ConfigPath)
+	a.Logger.Info("Successfully parsed config file", "location", a.ConfigPath)
 	a.Config = config
 
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -7,11 +7,12 @@ import (
 )
 
 const (
-	flagConfigPath  = "config"
-	flagVerbose     = "verbose"
-	flagLogLevel    = "log-level"
-	flagJSON        = "json"
-	flagMetricsPort = "metrics-port"
+	flagConfigPath    = "config"
+	flagVerbose       = "verbose"
+	flagLogLevel      = "log-level"
+	flagJSON          = "json"
+	flagMetricsPort   = "metrics-port"
+	flagFlushInterval = "flush-interval"
 )
 
 func addAppPersistantFlags(cmd *cobra.Command, a *AppState) *cobra.Command {
@@ -19,6 +20,7 @@ func addAppPersistantFlags(cmd *cobra.Command, a *AppState) *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&a.Debug, flagVerbose, "v", false, fmt.Sprintf("use this flag to set log level to `debug` (overrides %s flag)", flagLogLevel))
 	cmd.PersistentFlags().StringVar(&a.LogLevel, flagLogLevel, "info", "log level (debug, info, warn, error)")
 	cmd.PersistentFlags().Int16P(flagMetricsPort, "p", 2112, "customize Prometheus metrics port")
+	cmd.PersistentFlags().DurationP(flagFlushInterval, "i", 0, "how frequently should a flush routine be run")
 	return cmd
 
 }

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -64,6 +64,7 @@ func Start(a *AppState) *cobra.Command {
 				updateLatestHeight := 1 * time.Second
 				go c.TrackLatestBlockHeight(cmd.Context(), logger, updateLatestHeight)
 
+				time.Sleep(5 * time.Second)
 				if err := c.InitializeBroadcaster(cmd.Context(), logger, sequenceMap); err != nil {
 					logger.Error("Error initializing broadcaster", "err: ", err)
 					os.Exit(1)

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -54,6 +54,14 @@ func Start(a *AppState) *cobra.Command {
 				os.Exit(1)
 			}
 
+			flushInterval, err := cmd.Flags().GetDuration(flagFlushInterval)
+			if err != nil {
+				logger.Error("invalid flush interval", "error", err)
+			}
+			if flushInterval == 0 {
+				logger.Info("flush interval not set. Use the --flush-interval flag to set a reoccurring flush")
+			}
+
 			metrics := relayer.InitPromMetrics(port)
 
 			for name, cfg := range cfg.Chains {
@@ -83,7 +91,7 @@ func Start(a *AppState) *cobra.Command {
 					os.Exit(1)
 				}
 
-				go c.StartListener(cmd.Context(), logger, processingQueue)
+				go c.StartListener(cmd.Context(), logger, processingQueue, flushInterval)
 				go c.WalletBalanceMetric(cmd.Context(), a.Logger, metrics)
 
 				if _, ok := registeredDomains[c.Domain()]; ok {

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -78,8 +78,7 @@ func Start(a *AppState) *cobra.Command {
 					os.Exit(1)
 				}
 
-				updateLatestHeight := 1 * time.Second
-				go c.TrackLatestBlockHeight(cmd.Context(), logger, updateLatestHeight)
+				go c.TrackLatestBlockHeight(cmd.Context(), logger)
 
 				// wait until height is available
 				for c.LatestBlock() == 0 {

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -101,6 +101,7 @@ func Start(a *AppState) *cobra.Command {
 
 			<-cmd.Context().Done()
 			// clean up
+			time.Sleep(20 * time.Millisecond)
 			for _, c := range registeredDomains {
 				fmt.Printf("\n%s: latest-block: %d last-flushed-block: %d", c.Name(), c.LatestBlock(), c.LastFlushedBlock())
 				c.CloseClients()

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -73,7 +73,11 @@ func Start(a *AppState) *cobra.Command {
 				updateLatestHeight := 1 * time.Second
 				go c.TrackLatestBlockHeight(cmd.Context(), logger, updateLatestHeight)
 
-				time.Sleep(5 * time.Second)
+				// wait until height is available
+				for c.LatestBlock() == 0 {
+					time.Sleep(1 * time.Second)
+				}
+
 				if err := c.InitializeBroadcaster(cmd.Context(), logger, sequenceMap); err != nil {
 					logger.Error("Error initializing broadcaster", "error", err)
 					os.Exit(1)

--- a/ethereum/broadcast.go
+++ b/ethereum/broadcast.go
@@ -40,6 +40,8 @@ func (e *Ethereum) Broadcast(
 	sequenceMap *types.SequenceMap,
 ) error {
 
+	logger = logger.With("chain", e.name, "chain_id", e.chainID, "domain", e.domain)
+
 	// set up eth client
 	client, err := ethclient.Dial(e.rpcURL)
 	if err != nil {

--- a/ethereum/broadcast.go
+++ b/ethereum/broadcast.go
@@ -151,7 +151,7 @@ func (e *Ethereum) attemptBroadcast(
 		if response.Uint64() == uint64(1) {
 			// nonce has already been used, mark as complete
 			logger.Debug(fmt.Sprintf("This source domain/nonce has already been used: %d %d",
-				msg.SourceDomain, msg.Nonce))
+				msg.SourceDomain, msg.Nonce), "src-tx", msg.SourceTxHash, "reviever")
 			msg.Status = types.Complete
 			return nil
 		}

--- a/ethereum/broadcast.go
+++ b/ethereum/broadcast.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/strangelove-ventures/noble-cctp-relayer/ethereum/contracts"
 	"github.com/strangelove-ventures/noble-cctp-relayer/types"
 )
@@ -42,14 +41,7 @@ func (e *Ethereum) Broadcast(
 
 	logger = logger.With("chain", e.name, "chain_id", e.chainID, "domain", e.domain)
 
-	// set up eth client
-	client, err := ethclient.Dial(e.rpcURL)
-	if err != nil {
-		return fmt.Errorf("unable to dial ethereum client: %w", err)
-	}
-	defer client.Close()
-
-	backend := NewContractBackendWrapper(client)
+	backend := NewContractBackendWrapper(e.rpcClient)
 
 	auth, err := bind.NewKeyedTransactorWithChainID(e.privateKey, big.NewInt(e.chainID))
 	if err != nil {

--- a/ethereum/chain.go
+++ b/ethereum/chain.go
@@ -96,7 +96,16 @@ func (e *Ethereum) Domain() types.Domain {
 }
 
 func (e *Ethereum) LatestBlock() uint64 {
-	return e.latestBlock
+	e.mu.Lock()
+	block := e.latestBlock
+	e.mu.Unlock()
+	return block
+}
+
+func (e *Ethereum) SetLatestBlock(block uint64) {
+	e.mu.Lock()
+	e.latestBlock = block
+	e.mu.Unlock()
 }
 
 func (e *Ethereum) LastFlushedBlock() uint64 {

--- a/ethereum/listener.go
+++ b/ethereum/listener.go
@@ -6,14 +6,22 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"time"
 
 	"cosmossdk.io/log"
 	ethereum "github.com/ethereum/go-ethereum"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/pascaldekloe/etherstream"
 	"github.com/strangelove-ventures/noble-cctp-relayer/types"
+)
+
+var (
+	messageTransmitterABI     abi.ABI
+	messageSent               abi.Event
+	messageTransmitterAddress common.Address
 )
 
 func (e *Ethereum) StartListener(
@@ -23,109 +31,280 @@ func (e *Ethereum) StartListener(
 ) {
 	logger = logger.With("chain", e.name, "chain_id", e.chainID, "domain", e.domain)
 
-	// set up client
 	messageTransmitter, err := content.ReadFile("abi/MessageTransmitter.json")
 	if err != nil {
 		logger.Error("unable to read MessageTransmitter abi", "err", err)
 		os.Exit(1)
 	}
-	messageTransmitterABI, err := abi.JSON(bytes.NewReader(messageTransmitter))
+	messageTransmitterABI, err = abi.JSON(bytes.NewReader(messageTransmitter))
 	if err != nil {
 		logger.Error("unable to parse MessageTransmitter abi", "err", err)
-	}
-
-	messageSent := messageTransmitterABI.Events["MessageSent"]
-
-	ethClient, err := ethclient.DialContext(ctx, e.wsURL)
-	if err != nil {
-		logger.Error("unable to initialize ethereum client", "err", err)
 		os.Exit(1)
 	}
 
-	// defer ethClient.Close()
+	messageSent = messageTransmitterABI.Events["MessageSent"]
+	messageTransmitterAddress = common.HexToAddress(e.messageTransmitterAddress)
 
-	messageTransmitterAddress := common.HexToAddress(e.messageTransmitterAddress)
-	etherReader := etherstream.Reader{Backend: ethClient}
+	e.startListenerRoutines(ctx, logger, processingQueue)
+
+}
+
+// startListenerRoutines starts the ethereum websocket subscription, queries history pertaining to the lookback period,
+// and starts the reoccurring flush
+//
+// we pass the subscription from the initial queryEth() to flushMechanism() so in the case the
+// websocket becomes disconnect, we stop and then re-start the flush.
+func (e *Ethereum) startListenerRoutines(
+	ctx context.Context,
+	logger log.Logger,
+	processingQueue chan *types.TxState,
+) {
+
+	sub := e.queryAndConsume(ctx, logger, processingQueue)
+	go e.flushMechanism(ctx, logger, processingQueue, sub)
+}
+
+func (e *Ethereum) queryAndConsume(
+	ctx context.Context,
+	logger log.Logger,
+	processingQueue chan *types.TxState,
+
+) (sub ethereum.Subscription) {
+
+	var err error
+	var stream <-chan ethtypes.Log
+	var history []ethtypes.Log
+
+	etherReader := etherstream.Reader{Backend: e.wsClient}
 
 	if e.startBlock == 0 {
-		header, err := ethClient.HeaderByNumber(ctx, nil)
-		if err != nil {
-			logger.Error("unable to retrieve latest eth block header", "err", err)
-			os.Exit(1)
-		}
-
-		e.startBlock = header.Number.Uint64()
+		e.startBlock = e.latestBlock
 	}
+
+	latestBlock := e.latestBlock
+
+	// start initial stream ignoring lookback period
+	logger.Info(fmt.Sprintf("Starting Ethereum listener at block %d", e.startBlock))
 
 	query := ethereum.FilterQuery{
 		Addresses: []common.Address{messageTransmitterAddress},
 		Topics:    [][]common.Hash{{messageSent.ID}},
-		FromBlock: big.NewInt(int64(e.startBlock - e.lookbackPeriod)),
+		FromBlock: big.NewInt(int64(latestBlock)),
 	}
 
-	logger.Info(fmt.Sprintf(
-		"Starting Ethereum listener at block %d looking back %d blocks",
-		e.startBlock,
-		e.lookbackPeriod))
-
-	// websockets do not query history
-	// https://github.com/ethereum/go-ethereum/issues/15063
-	stream, sub, history, err := etherReader.QueryWithHistory(ctx, &query)
-	if err != nil {
-		logger.Error("unable to subscribe to logs", "err", err)
-		os.Exit(1)
+	queryAttempt := 1
+	for {
+		// websockets do not query history
+		// https://github.com/ethereum/go-ethereum/issues/15063
+		stream, sub, history, err = etherReader.QueryWithHistory(ctx, &query)
+		if err != nil {
+			logger.Error("unable to subscribe to logs", "attempt", queryAttempt, "err", err)
+			queryAttempt++
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		break
 	}
 
-	// process history
+	go e.consumeStream(ctx, logger, processingQueue, stream, sub)
+	consumeHistroy(logger, history, processingQueue)
+
+	if e.lookbackPeriod == 0 {
+		return sub
+	}
+
+	// handle lookback period in chunks (some websockets only allow small history queries)
+	chunkSize := uint64(100)
+	var toUnSub ethereum.Subscription
+
+	for start := (latestBlock - e.lookbackPeriod); start < latestBlock; start += chunkSize {
+		end := start + chunkSize
+		if end > latestBlock {
+			end = latestBlock
+		}
+
+		logger.Info(fmt.Sprintf("getting history in chunks: start-block: %d end-block: %d", start, end))
+
+		query = ethereum.FilterQuery{
+			Addresses: []common.Address{messageTransmitterAddress},
+			Topics:    [][]common.Hash{{messageSent.ID}},
+			FromBlock: big.NewInt(int64(start)),
+			ToBlock:   big.NewInt(int64(end)),
+		}
+		queryAttempt = 1
+		for {
+			_, toUnSub, history, err = etherReader.QueryWithHistory(ctx, &query)
+			if err != nil {
+				logger.Error("unable to query history from %d to %d. attempt: %d", start, end, queryAttempt)
+				queryAttempt++
+				time.Sleep(1 * time.Second)
+				continue
+			}
+			break
+		}
+		toUnSub.Unsubscribe()
+		consumeHistroy(logger, history, processingQueue)
+	}
+
+	logger.Info("done querying lookback period. All caught up")
+
+	return sub
+}
+
+// consumeHistroy consumes the hisroty from a QueryWithHistory() go-ethereum call.
+// it passes messages to the processingQueue
+func consumeHistroy(
+	logger log.Logger,
+	history []ethtypes.Log,
+	processingQueue chan *types.TxState,
+) {
 	for _, historicalLog := range history {
 		parsedMsg, err := types.EvmLogToMessageState(messageTransmitterABI, messageSent, &historicalLog)
 		if err != nil {
-			logger.Error("Unable to parse history log into MessageState, skipping", "err", err)
+			logger.Error("Unable to parse history log into MessageState, skipping", "tx hash", historicalLog.TxHash.Hex(), "err", err)
 			continue
 		}
 		logger.Info(fmt.Sprintf("New historical msg from source domain %d with tx hash %s", parsedMsg.SourceDomain, parsedMsg.SourceTxHash))
 
 		processingQueue <- &types.TxState{TxHash: parsedMsg.SourceTxHash, Msgs: []*types.MessageState{parsedMsg}}
-
-		// It might help to wait a small amount of time between sending messages into the processing queue
-		// so that account sequences / nonces are set correctly
-		// time.Sleep(10 * time.Millisecond)
 	}
+}
 
-	// consume stream
-	go func() {
-		var txState *types.TxState
-		for {
-			select {
-			case <-ctx.Done():
-				ethClient.Close()
-				return
-			case err := <-sub.Err():
-				logger.Error("connection closed", "err", err)
-				ethClient.Close()
-				os.Exit(1)
-			case streamLog := <-stream:
-				parsedMsg, err := types.EvmLogToMessageState(messageTransmitterABI, messageSent, &streamLog)
-				if err != nil {
-					logger.Error("Unable to parse ws log into MessageState, skipping")
-					continue
-				}
-				logger.Info(fmt.Sprintf("New stream msg from %d with tx hash %s", parsedMsg.SourceDomain, parsedMsg.SourceTxHash))
-				if txState == nil {
-					txState = &types.TxState{TxHash: parsedMsg.SourceTxHash, Msgs: []*types.MessageState{parsedMsg}}
-				} else if parsedMsg.SourceTxHash != txState.TxHash {
-					processingQueue <- txState
-					txState = &types.TxState{TxHash: parsedMsg.SourceTxHash, Msgs: []*types.MessageState{parsedMsg}}
-				} else {
-					txState.Msgs = append(txState.Msgs, parsedMsg)
+// consumeStream consumes incoming transactions from a QueryWithHistory() go-ethereum call.
+// if the websocket is disconnect, it restarts the stream using the last seen block height as the start height.
+func (e *Ethereum) consumeStream(
+	ctx context.Context,
+	logger log.Logger,
+	processingQueue chan *types.TxState,
+	stream <-chan ethtypes.Log,
+	sub ethereum.Subscription,
+) {
+	var txState *types.TxState
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case err := <-sub.Err():
+			// setting start block to 0 will start listener from latsest height.
+			// in the rare case we are waiting for the websocket to come back on line for a long period of time,
+			// we'll rely on the latestFlushBlock to flush out all missted transactions
+			e.startBlock = 0
+			logger.Error("connection closed. Restarting...", "err", err)
+			e.startListenerRoutines(ctx, logger, processingQueue)
+			return
+		case streamLog := <-stream:
+			parsedMsg, err := types.EvmLogToMessageState(messageTransmitterABI, messageSent, &streamLog)
+			if err != nil {
+				logger.Error("Unable to parse ws log into MessageState, skipping", "source tx", streamLog.TxHash.Hex(), "err", err)
+				continue
+			}
+			logger.Info(fmt.Sprintf("New stream msg from %d with tx hash %s", parsedMsg.SourceDomain, parsedMsg.SourceTxHash))
+			if txState == nil {
+				txState = &types.TxState{TxHash: parsedMsg.SourceTxHash, Msgs: []*types.MessageState{parsedMsg}}
+			} else if parsedMsg.SourceTxHash != txState.TxHash {
+				processingQueue <- txState
+				txState = &types.TxState{TxHash: parsedMsg.SourceTxHash, Msgs: []*types.MessageState{parsedMsg}}
+			} else {
+				txState.Msgs = append(txState.Msgs, parsedMsg)
 
-				}
-			default:
-				if txState != nil {
-					processingQueue <- txState
-					txState = nil
-				}
+			}
+		default:
+			if txState != nil {
+				processingQueue <- txState
+				txState = nil
 			}
 		}
-	}()
+	}
+}
+
+func (e *Ethereum) flushMechanism(
+	ctx context.Context,
+	logger log.Logger,
+	processingQueue chan *types.TxState,
+	sub ethereum.Subscription,
+) {
+
+	var toUnSub ethereum.Subscription
+	var history []ethtypes.Log
+	var err error
+
+	etherReader := etherstream.Reader{Backend: e.wsClient}
+	chunkSize := uint64(100)
+	for {
+		timer := time.NewTimer(5 * time.Minute)
+		select {
+		case <-timer.C:
+			if e.lastFlushedBlock == 0 {
+				e.lastFlushedBlock = e.latestBlock
+			}
+
+			latestBlock := e.latestBlock
+
+			for start := (e.lastFlushedBlock - e.lookbackPeriod); start < latestBlock; start += chunkSize {
+				end := start + chunkSize
+				if end > latestBlock {
+					end = latestBlock
+				}
+
+				logger.Info(fmt.Sprintf("flushing... querying history in chunks: start-block: %d end-block: %d", start, end))
+
+				query := ethereum.FilterQuery{
+					Addresses: []common.Address{messageTransmitterAddress},
+					Topics:    [][]common.Hash{{messageSent.ID}},
+					FromBlock: big.NewInt(int64(start)),
+					ToBlock:   big.NewInt(int64(end)),
+				}
+				queryAttempt := 1
+				for {
+					_, toUnSub, history, err = etherReader.QueryWithHistory(ctx, &query)
+					if err != nil {
+						logger.Error("unable to query history during flush", "err", err)
+						queryAttempt++
+						time.Sleep(1 * time.Second)
+						continue
+					}
+					break
+				}
+				toUnSub.Unsubscribe()
+				consumeHistroy(logger, history, processingQueue)
+			}
+			logger.Info("flush complete")
+
+		// if main websocket stream is disconnected, stop flush. It will be restarted once websocket is reconnected
+		case <-sub.Err():
+			logger.Info("websocket disconnected, stopping flush mechanism. Will restart after websocket is re-established")
+			return
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		}
+	}
+}
+
+func (e *Ethereum) TrackLatestBlockHeight(ctx context.Context, logger log.Logger, loop time.Duration) {
+	logger.With("routine", "TrackLatestBlockHeight", "chain", e.name, "domain", e.domain)
+
+	// first time
+	header, err := e.rpcClient.HeaderByNumber(ctx, nil)
+	if err != nil {
+		logger.Error("Error getting lastest block height:", err)
+	}
+	e.latestBlock = header.Number.Uint64()
+
+	// then start loop on a timer
+	for {
+		timer := time.NewTimer(loop)
+		select {
+		case <-timer.C:
+			header, err := e.rpcClient.HeaderByNumber(ctx, nil)
+			if err != nil {
+				logger.Error("Error getting lastest block height:", err)
+			}
+			e.latestBlock = header.Number.Uint64()
+
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		}
+	}
 }

--- a/ethereum/listener.go
+++ b/ethereum/listener.go
@@ -11,7 +11,6 @@ import (
 	"cosmossdk.io/log"
 	ethereum "github.com/ethereum/go-ethereum"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -69,7 +68,7 @@ func (e *Ethereum) startListenerRoutines(
 
 	// query history pertaining to lookback period
 	if e.lookbackPeriod != 0 {
-		latestBlock := e.latestBlock
+		latestBlock := e.LatestBlock()
 		start := latestBlock - e.lookbackPeriod
 		end := latestBlock
 		logger.Info(fmt.Sprintf("starting lookback of %d blocks", e.lookbackPeriod))
@@ -91,10 +90,10 @@ func (e *Ethereum) startMainStream(
 	etherReader := etherstream.Reader{Backend: e.wsClient}
 
 	if e.startBlock == 0 {
-		e.startBlock = e.latestBlock
+		e.startBlock = e.LatestBlock()
 	}
 
-	latestBlock := e.latestBlock
+	latestBlock := e.LatestBlock()
 
 	// start initial stream (lookback period handled separately)
 	logger.Info(fmt.Sprintf("Starting Ethereum listener at block %d", e.startBlock))
@@ -253,7 +252,7 @@ func (e *Ethereum) flushMechanism(
 		timer := time.NewTimer(5 * time.Minute)
 		select {
 		case <-timer.C:
-			latestBlock := e.latestBlock
+			latestBlock := e.LatestBlock()
 
 			if e.lastFlushedBlock == 0 {
 				e.lastFlushedBlock = latestBlock
@@ -264,6 +263,8 @@ func (e *Ethereum) flushMechanism(
 			logger.Info(fmt.Sprintf("flush started from %d to %d", start, latestBlock))
 
 			e.getAndConsumeHistory(ctx, logger, processingQueue, start, latestBlock)
+
+			e.lastFlushedBlock = latestBlock
 
 			logger.Info("flush complete")
 
@@ -287,7 +288,9 @@ func (e *Ethereum) TrackLatestBlockHeight(ctx context.Context, logger log.Logger
 	if err != nil {
 		logger.Error("Error getting lastest block height:", err)
 	}
-	e.latestBlock = header.Number.Uint64()
+	if err == nil {
+		e.SetLatestBlock(header.Number.Uint64())
+	}
 
 	// then start loop on a timer
 	for {
@@ -299,7 +302,7 @@ func (e *Ethereum) TrackLatestBlockHeight(ctx context.Context, logger log.Logger
 				logger.Error("Error getting lastest block height:", err)
 				continue
 			}
-			e.latestBlock = header.Number.Uint64()
+			e.SetLatestBlock(header.Number.Uint64())
 
 		case <-ctx.Done():
 			timer.Stop()
@@ -312,41 +315,22 @@ func (e *Ethereum) WalletBalanceMetric(ctx context.Context, logger log.Logger, m
 	logger = logger.With("metric", "wallet blance", "chain", e.name, "domain", e.domain)
 	queryRate := 30 * time.Second
 
-	var err error
-	var client *ethclient.Client
-
 	account := common.HexToAddress(e.minterAddress)
 
 	exponent := big.NewInt(int64(e.MetricsExponent))                                      // ex: 18
 	scaleFactor := new(big.Float).SetInt(new(big.Int).Exp(big.NewInt(10), exponent, nil)) // ex: 10^18
 
-	defer func() {
-		if client != nil {
-			client.Close()
-		}
-	}()
-
 	first := make(chan struct{}, 1)
 	first <- struct{}{}
-	createClient := true
 	for {
 		timer := time.NewTimer(queryRate)
 		select {
 		// don't wait the "queryRate" amount of time if this is the first time running
 		case <-first:
 			timer.Stop()
-			if createClient {
-				client, err = ethclient.DialContext(ctx, e.rpcURL)
-				if err != nil {
-					logger.Error(fmt.Sprintf("error dialing eth client. Will try again in %d sec", queryRate), "error", err)
-					createClient = true
-					continue
-				}
-			}
-			balance, err := client.BalanceAt(ctx, account, nil)
+			balance, err := e.rpcClient.BalanceAt(ctx, account, nil)
 			if err != nil {
 				logger.Error(fmt.Sprintf("error querying balance. Will try again in %d sec", queryRate), "error", err)
-				createClient = true
 				continue
 			}
 
@@ -354,21 +338,10 @@ func (e *Ethereum) WalletBalanceMetric(ctx context.Context, logger log.Logger, m
 			balanceScaled, _ := new(big.Float).Quo(balanceBigFloat, scaleFactor).Float64()
 
 			m.SetWalletBalance(e.name, e.minterAddress, e.MetricsDenom, balanceScaled)
-
-			createClient = false
 		case <-timer.C:
-			if createClient {
-				client, err = ethclient.DialContext(ctx, e.rpcURL)
-				if err != nil {
-					logger.Error(fmt.Sprintf("error dialing eth client. Will try again in %d sec", queryRate), "error", err)
-					createClient = true
-					continue
-				}
-			}
-			balance, err := client.BalanceAt(ctx, account, nil)
+			balance, err := e.rpcClient.BalanceAt(ctx, account, nil)
 			if err != nil {
 				logger.Error(fmt.Sprintf("error querying balance. Will try again in %d sec", queryRate), "error", err)
-				createClient = true
 				continue
 			}
 
@@ -377,7 +350,6 @@ func (e *Ethereum) WalletBalanceMetric(ctx context.Context, logger log.Logger, m
 
 			m.SetWalletBalance(e.name, e.minterAddress, e.MetricsDenom, balanceScaled)
 
-			createClient = false
 		case <-ctx.Done():
 			timer.Stop()
 			return

--- a/ethereum/listener.go
+++ b/ethereum/listener.go
@@ -147,13 +147,15 @@ func (e *Ethereum) getAndConsumeHistory(
 	var history []ethtypes.Log
 	var err error
 
-	// handle historical queries in chunks (some websockets only allow small history queries)
-	chunkSize := uint64(100)
-	chunk := 1
-	totalChunksNeeded := (end - start) / chunkSize
-	if (end-start)%chunkSize > 0 || totalChunksNeeded == 0 {
-		totalChunksNeeded++
+	if start > end {
+		logger.Error(fmt.Sprintf("Unable to get history from %d to %d where the start block is greater than the end block", start, end))
+		return
 	}
+
+	// handle historical queries in chunks (some websockets only allow small history queries)
+	const chunkSize = uint64(100)
+	chunk := 1
+	totalChunksNeeded := (end - start + chunkSize - 1) / chunkSize
 
 	for start < end {
 		fromBlock := start

--- a/ethereum/listener.go
+++ b/ethereum/listener.go
@@ -272,6 +272,7 @@ func (e *Ethereum) flushMechanism(
 
 		// if main websocket stream is disconnected, stop flush. It will be restarted once websocket is reconnected
 		case <-sub.Err():
+			timer.Stop()
 			logger.Info("websocket disconnected, stopping flush mechanism. Will restart after websocket is re-established")
 			return
 		case <-ctx.Done():

--- a/ethereum/listener.go
+++ b/ethereum/listener.go
@@ -62,6 +62,8 @@ func (e *Ethereum) startListenerRoutines(
 
 	sub := e.queryAndConsume(ctx, logger, processingQueue)
 	go e.flushMechanism(ctx, logger, processingQueue, sub)
+
+	<-sub.Err()
 }
 
 func (e *Ethereum) queryAndConsume(

--- a/ethereum/listener_test.go
+++ b/ethereum/listener_test.go
@@ -27,7 +27,7 @@ func TestStartListener(t *testing.T) {
 
 	processingQueue := make(chan *types.TxState, 10000)
 
-	go eth.StartListener(ctx, a.Logger, processingQueue)
+	go eth.StartListener(ctx, a.Logger, processingQueue, 0)
 
 	time.Sleep(5 * time.Second)
 

--- a/integration/eth_burn_to_noble_mint_test.go
+++ b/integration/eth_burn_to_noble_mint_test.go
@@ -54,6 +54,11 @@ func TestEthBurnToNobleMint(t *testing.T) {
 	ethChain, err := ethCfg.Chain("eth")
 	require.NoError(t, err)
 
+	err = nobleChain.InitializeClients(ctx, a.Logger)
+	require.NoError(t, err)
+	err = ethChain.InitializeClients(ctx, a.Logger)
+	require.NoError(t, err)
+
 	var burnAmount = big.NewInt(1)
 
 	fmt.Println("Starting relayer...")

--- a/integration/eth_burn_to_noble_mint_test.go
+++ b/integration/eth_burn_to_noble_mint_test.go
@@ -72,7 +72,7 @@ func TestEthBurnToNobleMint(t *testing.T) {
 
 	processingQueue := make(chan *types.TxState, 10)
 
-	go ethChain.StartListener(ctx, a.Logger, processingQueue)
+	go ethChain.StartListener(ctx, a.Logger, processingQueue, 0)
 	go cmd.StartProcessor(ctx, a, registeredDomains, processingQueue, sequenceMap)
 
 	_, _, generatedWallet := testdata.KeyTestPubAddr()

--- a/integration/noble_burn_to_eth_mint_test.go
+++ b/integration/noble_burn_to_eth_mint_test.go
@@ -60,6 +60,11 @@ func TestNobleBurnToEthMint(t *testing.T) {
 	ethChain, err := ethCfg.Chain("eth")
 	require.NoError(t, err)
 
+	err = nobleChain.InitializeClients(ctx, a.Logger)
+	require.NoError(t, err)
+	err = ethChain.InitializeClients(ctx, a.Logger)
+	require.NoError(t, err)
+
 	fmt.Println("Starting relayer...")
 
 	registeredDomains := make(map[types.Domain]types.Chain)

--- a/integration/noble_burn_to_eth_mint_test.go
+++ b/integration/noble_burn_to_eth_mint_test.go
@@ -77,7 +77,7 @@ func TestNobleBurnToEthMint(t *testing.T) {
 
 	processingQueue := make(chan *types.TxState, 10)
 
-	go nobleChain.StartListener(ctx, a.Logger, processingQueue)
+	go nobleChain.StartListener(ctx, a.Logger, processingQueue, 0)
 	go cmd.StartProcessor(ctx, a, registeredDomains, processingQueue, sequenceMap)
 
 	ethDestinationAddress, _, err := generateEthWallet()

--- a/noble/broadcast.go
+++ b/noble/broadcast.go
@@ -67,7 +67,7 @@ func (n *Noble) Broadcast(
 		}
 
 		// Log retry information
-		logger.Error("Broadcasting to noble failed. Retrying...", "error", err, "interval_seconds", n.retryIntervalSeconds)
+		logger.Error(fmt.Sprintf("Broadcasting to noble failed. Attempt %d/%d Retrying...", attempt, n.maxRetries), "error", err, "interval_seconds", n.retryIntervalSeconds, "src-tx", msgs[0].SourceTxHash)
 		time.Sleep(time.Duration(n.retryIntervalSeconds) * time.Second)
 	}
 
@@ -99,7 +99,12 @@ func (n *Noble) attemptBroadcast(
 
 		if used {
 			msg.Status = types.Complete
-			logger.Info(fmt.Sprintf("Noble cctp minter nonce %d already used", msg.Nonce))
+			// bm, _ := new(cctptypes.BurnMessage).Parse(msg.MsgBody)
+			// x, err := hex.DecodeString(string(bm.MintRecipient))
+			// fmt.Println("err", err)
+			// y := common.HexToAddress(string(x))
+			// fmt.Println("ERRR", err)
+			logger.Info(fmt.Sprintf("Noble cctp minter nonce %d already used.", msg.Nonce), "src-tx", msg.SourceTxHash)
 			continue
 		}
 

--- a/noble/broadcast.go
+++ b/noble/broadcast.go
@@ -60,7 +60,7 @@ func (n *Noble) Broadcast(
 	txBuilder := sdkContext.TxConfig.NewTxBuilder()
 
 	// sign and broadcast txn
-	for attempt := 0; attempt <= n.maxRetries; attempt++ {
+	for attempt := 1; attempt <= n.maxRetries; attempt++ {
 		err := n.attemptBroadcast(ctx, logger, msgs, sequenceMap, sdkContext, txBuilder)
 		if err == nil {
 			return nil

--- a/noble/broadcast.go
+++ b/noble/broadcast.go
@@ -99,11 +99,6 @@ func (n *Noble) attemptBroadcast(
 
 		if used {
 			msg.Status = types.Complete
-			// bm, _ := new(cctptypes.BurnMessage).Parse(msg.MsgBody)
-			// x, err := hex.DecodeString(string(bm.MintRecipient))
-			// fmt.Println("err", err)
-			// y := common.HexToAddress(string(x))
-			// fmt.Println("ERRR", err)
 			logger.Info(fmt.Sprintf("Noble cctp minter nonce %d already used.", msg.Nonce), "src-tx", msg.SourceTxHash)
 			continue
 		}

--- a/noble/chain.go
+++ b/noble/chain.go
@@ -109,7 +109,16 @@ func (n *Noble) Domain() types.Domain {
 }
 
 func (n *Noble) LatestBlock() uint64 {
-	return n.latestBlock
+	n.mu.Lock()
+	block := n.latestBlock
+	n.mu.Unlock()
+	return block
+}
+
+func (n *Noble) SetLatestBlock(block uint64) {
+	n.mu.Lock()
+	n.latestBlock = block
+	n.mu.Unlock()
 }
 
 func (n *Noble) LastFlushedBlock() uint64 {

--- a/noble/listener.go
+++ b/noble/listener.go
@@ -20,6 +20,8 @@ func (n *Noble) StartListener(
 ) {
 	logger = logger.With("chain", n.Name(), "chain_id", n.chainID, "domain", n.Domain())
 
+	flushInterval = flushInterval_
+
 	if n.startBlock == 0 {
 		n.startBlock = n.LatestBlock()
 	}

--- a/noble/listener.go
+++ b/noble/listener.go
@@ -94,7 +94,7 @@ func (n *Noble) StartListener(
 					block := <-blockQueue
 					res, err := n.cc.RPCClient.TxSearch(ctx, fmt.Sprintf("tx.height=%d", block), false, nil, nil, "")
 					if err != nil || res == nil {
-						logger.Debug(fmt.Sprintf("unable to query Noble block %d. Will retry.", block), "error:", err)
+						logger.Debug(fmt.Sprintf("Unable to query Noble block %d. Will retry.", block), "error:", err)
 						blockQueue <- block
 						continue
 					}
@@ -102,7 +102,7 @@ func (n *Noble) StartListener(
 					for _, tx := range res.Txs {
 						parsedMsgs, err := txToMessageState(tx)
 						if err != nil {
-							logger.Error("unable to parse Noble log to message state", "err", err.Error())
+							logger.Error("Unable to parse Noble log to message state", "err", err.Error())
 							continue
 						}
 						for _, parsedMsg := range parsedMsgs {
@@ -128,7 +128,7 @@ func (n *Noble) flushMechanism(
 	blockQueue chan uint64,
 ) {
 
-	logger.Debug(fmt.Sprintf("flush mechanism started. Will flush every %v", flushInterval))
+	logger.Debug(fmt.Sprintf("Flush mechanism started. Will flush every %v", flushInterval))
 
 	for {
 		timer := time.NewTimer(flushInterval)
@@ -139,11 +139,11 @@ func (n *Noble) flushMechanism(
 			// test to see that the rpc is available before attempting flush
 			res, err := n.cc.RPCClient.Status(ctx)
 			if err != nil {
-				logger.Error(fmt.Sprintf("skipping flush... error reaching out to rpc, will retry flush in %v", flushInterval))
+				logger.Error(fmt.Sprintf("Skipping flush... error reaching out to rpc, will retry flush in %v", flushInterval))
 				continue
 			}
 			if res.SyncInfo.CatchingUp {
-				logger.Error(fmt.Sprintf("skipping flush... rpc still catching, will retry flush in %v", flushInterval))
+				logger.Error(fmt.Sprintf("Skipping flush... rpc still catching, will retry flush in %v", flushInterval))
 				continue
 			}
 
@@ -154,14 +154,14 @@ func (n *Noble) flushMechanism(
 
 			flushStart := lastFlushedBlock - n.lookbackPeriod
 
-			logger.Info(fmt.Sprintf("flush started from: %d to: %d", flushStart, latestBlock))
+			logger.Info(fmt.Sprintf("Flush started from: %d to: %d", flushStart, latestBlock))
 
 			for i := flushStart; i <= latestBlock; i++ {
 				blockQueue <- i
 			}
 			n.lastFlushedBlock = latestBlock
 
-			logger.Info("flush complete")
+			logger.Info("Flush complete")
 
 		case <-ctx.Done():
 			timer.Stop()
@@ -170,24 +170,24 @@ func (n *Noble) flushMechanism(
 	}
 }
 
-func (n *Noble) TrackLatestBlockHeight(ctx context.Context, logger log.Logger, loop time.Duration) {
+func (n *Noble) TrackLatestBlockHeight(ctx context.Context, logger log.Logger) {
 	logger.With("routine", "TrackLatestBlockHeight", "chain", n.Name(), "domain", n.Domain())
 
 	// first time
 	res, err := n.cc.RPCClient.Status(ctx)
 	if err != nil {
-		logger.Error("unable to query Nobles latest height", "err", err)
+		logger.Error("Unable to query Nobles latest height", "err", err)
 	}
 	n.SetLatestBlock(uint64(res.SyncInfo.LatestBlockHeight))
 
 	// then start loop on a timer
 	for {
-		timer := time.NewTimer(loop)
+		timer := time.NewTimer(6 * time.Second)
 		select {
 		case <-timer.C:
 			res, err := n.cc.RPCClient.Status(ctx)
 			if err != nil {
-				logger.Error("unable to query Nobles latest height", "err", err)
+				logger.Error("Unable to query Nobles latest height", "err", err)
 				continue
 			}
 			n.SetLatestBlock(uint64(res.SyncInfo.LatestBlockHeight))

--- a/noble/listener.go
+++ b/noble/listener.go
@@ -134,7 +134,7 @@ func (n *Noble) flushMechanism(
 
 			flushStart := lastFlushedBlock - n.lookbackPeriod
 
-			logger.Info(fmt.Sprintf("flushing... start-block: %d end-block: %d", flushStart, latestBlock))
+			logger.Info(fmt.Sprintf("flush started from: %d to: %d", flushStart, latestBlock))
 
 			for i := flushStart; i <= latestBlock; i++ {
 				blockQueue <- i

--- a/noble/listener.go
+++ b/noble/listener.go
@@ -91,7 +91,7 @@ func (n *Noble) StartListener(
 					block := <-blockQueue
 					res, err := n.cc.RPCClient.TxSearch(ctx, fmt.Sprintf("tx.height=%d", block), false, nil, nil, "")
 					if err != nil || res == nil {
-						logger.Debug(fmt.Sprintf("unable to query Noble block %d", block), "error:", err)
+						logger.Debug(fmt.Sprintf("unable to query Noble block %d. Will retry.", block), "error:", err)
 						blockQueue <- block
 						continue
 					}

--- a/noble/listener_test.go
+++ b/noble/listener_test.go
@@ -26,7 +26,7 @@ func TestStartListener(t *testing.T) {
 
 	processingQueue := make(chan *types.TxState, 10000)
 
-	go n.StartListener(ctx, a.Logger, processingQueue)
+	go n.StartListener(ctx, a.Logger, processingQueue, 0)
 
 	time.Sleep(20 * time.Second)
 

--- a/types/chain.go
+++ b/types/chain.go
@@ -19,6 +19,9 @@ type Chain interface {
 	// LatestBlockain returns the last queired height of the chain
 	LatestBlock() uint64
 
+	// SetLatestBlock sets the latest block
+	SetLatestBlock(block uint64)
+
 	// LastFlushedBlock returns the last block included in a flush. In the rare situation of a crash,
 	// this block is a good block to start at to catch up on any missed transactions.
 	LastFlushedBlock() uint64

--- a/types/chain.go
+++ b/types/chain.go
@@ -65,7 +65,6 @@ type Chain interface {
 	TrackLatestBlockHeight(
 		ctx context.Context,
 		logger log.Logger,
-		loop time.Duration,
 	)
 
 	WalletBalanceMetric(

--- a/types/chain.go
+++ b/types/chain.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"time"
 
 	"cosmossdk.io/log"
 )
@@ -14,9 +15,25 @@ type Chain interface {
 	// Domain returns the domain ID of the chain.
 	Domain() Domain
 
+	// LatestBlockain returns the last queired height of the chain
+	LatestBlock() uint64
+
+	// LastFlushedBlock returns the last block included in a flush. In the rare situation of a crash,
+	// this block is a good block to start at to catch up on any missed transactions.
+	LastFlushedBlock() uint64
+
 	// IsDestinationCaller returns true if the specified destination caller is the minter for the specified domain OR
 	// if destination caller is a zero byte array(left empty in deposit for burn message)
 	IsDestinationCaller(destinationCaller []byte) bool
+
+	// InitializeClients initializes the rpc and or websocket clients.
+	InitializeClients(
+		ctx context.Context,
+		logger log.Logger,
+	) error
+
+	// CloseClients is a cleanup function to close any open clients
+	CloseClients()
 
 	// InitializeBroadcaster initializes the minter account info for the chain.
 	InitializeBroadcaster(
@@ -39,4 +56,10 @@ type Chain interface {
 		msgs []*MessageState,
 		sequenceMap *SequenceMap,
 	) error
+
+	TrackLatestBlockHeight(
+		ctx context.Context,
+		logger log.Logger,
+		loop time.Duration,
+	)
 }

--- a/types/chain.go
+++ b/types/chain.go
@@ -51,6 +51,7 @@ type Chain interface {
 		ctx context.Context,
 		logger log.Logger,
 		processingQueue chan *TxState,
+		flushInterval time.Duration,
 	)
 
 	// Broadcast broadcasts CCTP mint messages to the chain.

--- a/types/message_state.go
+++ b/types/message_state.go
@@ -79,7 +79,7 @@ func EvmLogToMessageState(abi abi.ABI, messageSent abi.Event, log *ethtypes.Log)
 		return messageState, nil
 	}
 
-	return nil, fmt.Errorf("unable to parse tx into message, tx hash %s", log.TxHash.Hex())
+	return nil, fmt.Errorf("unable to parse tx into message, err: %w", err)
 }
 
 // Equal checks if two MessageState instances are equal


### PR DESCRIPTION
This PR solves several issues.

## Introduce reoccurring flush
The `start` command not accepts a  `--flush-interval` or `-i` flag and takes a duration.

The relayer now tracks the "last-flushed-block".

When a flush interval is set:
The relayer will continuously look back `last-flushed-block - lookback period up to the latest block` and perform a flush.

(`last-flushed-block - lookback period` may be overkill? Potentially just flush `last-flushed-block up to latest block` ?)

## Handle disconnected ETH web sockets

Prior to this PR, if an ETH/L2 web socket was disconnected, the relayer would crash. We relied on the infrastructure the relayer was deployed in to restart it. We now handle disconnections gracefully picking up where it left off. 

This will also:
- help with reviewing logs in a remote infrastructure as the logs were reset after each crash. 
- enable more accurate future metrics


## Allow for larger ETH/L2 history queries 
Depending on your ETH/L2 node or provider, you are only able to query a certain amount of history at once (we were running into this issue specifically with Avalanche). Now all ETH/L2 history queries are blocked in chunks of 100 blocks at a time.

## Better handling of Clients and Cosmos Providers
This PR introduces `InitializeClients()` and `CloseClients()` to the chain interface. This allows for better handling of clients/providers and allows for an organized cleanup in the event of a termination.