### PR TITLE
Add extra checks for `completed` messages

### DIFF
--- a/ethereum/contract_backend_wrapper.go
+++ b/ethereum/contract_backend_wrapper.go
@@ -2,7 +2,6 @@ package ethereum
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -19,10 +18,5 @@ func NewContractBackendWrapper(client *ethclient.Client) *ContractBackendWrapper
 }
 
 func (c *ContractBackendWrapper) SendTransaction(ctx context.Context, tx *types.Transaction) error {
-	json, err := tx.MarshalJSON()
-	if err != nil {
-		return err
-	}
-	fmt.Printf("SendTransaction: %+v\n\nRAW: %s\n", tx, json)
 	return c.Client.SendTransaction(ctx, tx)
 }

--- a/noble/broadcast.go
+++ b/noble/broadcast.go
@@ -103,6 +103,11 @@ func (n *Noble) attemptBroadcast(
 			continue
 		}
 
+		// check if another worker already broadcasted tx due to flush
+		if msg.Status == types.Complete {
+			continue
+		}
+
 		attestationBytes, err := hex.DecodeString(msg.Attestation[2:])
 		if err != nil {
 			return fmt.Errorf("unable to decode message attestation")

--- a/noble/message_state.go
+++ b/noble/message_state.go
@@ -73,8 +73,6 @@ func txToMessageState(tx *ctypes.ResultTx) ([]*types.MessageState, error) {
 					}
 
 					messageStates = append(messageStates, messageState)
-
-					fmt.Printf("Appended transfer from 4 to %d\n", msg.DestinationDomain)
 				}
 			}
 			if !parsed {


### PR DESCRIPTION
Because of the recent flush, the same message can be `dequeued` from the processing queue more than once. 

Ref: 
https://github.com/strangelove-ventures/noble-cctp-relayer/blob/d74f65466005f7a0a3292a700b9315641e017f33/cmd/process.go#L144

The PR adds extra checks to see if another worker had already completed the broadcast during each retry. 

Also, this cleans up some rogue print statements. 