### PR TITLE
Add Circle Attestation Retry Limit

### DIFF
--- a/cmd/appstate.go
+++ b/cmd/appstate.go
@@ -68,5 +68,18 @@ func (a *AppState) loadConfigFile() {
 	}
 	a.Logger.Info("Successfully parsed config file", "location", a.ConfigPath)
 	a.Config = config
+	a.validateConfig()
+}
 
+// validateConfig checks the AppState Config for any invalid settings.
+func (a *AppState) validateConfig() {
+	if a.Config.Circle.AttestationBaseUrl == "" {
+		a.Logger.Error("AttestationBaseUrl is required in the config")
+		os.Exit(1)
+	}
+
+	if a.Config.Circle.FetchRetryInterval == 0 {
+		a.Logger.Error("FetchRetryInterval must be greater than zero in the config")
+		os.Exit(1)
+	}
 }

--- a/types/message_state.go
+++ b/types/message_state.go
@@ -27,8 +27,9 @@ const (
 type Domain uint32
 
 type TxState struct {
-	TxHash string
-	Msgs   []*MessageState
+	TxHash       string
+	Msgs         []*MessageState
+	RetryAttempt int
 }
 
 type MessageState struct {


### PR DESCRIPTION
Closes #74 

Changes:
- Adds a new field to tx state which tracks the number of attestation attempts on a transaction. Previously the processor routines would retry indefinitely. That is no longer the case. When the limit is exceeded, the relayer will log the faulty transaction. 
- Refactored nested if statements for readability
- Refactored redundant sleep calls

Future update: I would like to move the sleep event to it's own routine or worker group as to not freeze a processor routine.