### PR TITLE
Reduce Chain Queries & Subscriptions

### DIFF
--- a/ethereum/listener.go
+++ b/ethereum/listener.go
@@ -279,16 +279,20 @@ func (e *Ethereum) flushMechanism(
 		case <-timer.C:
 			latestBlock := e.LatestBlock()
 
+			// initialize first lastFlushedBlock if not set
 			if e.lastFlushedBlock == 0 {
-				e.lastFlushedBlock = latestBlock
+				e.lastFlushedBlock = latestBlock - e.lookbackPeriod
 			}
 
-			start := e.lastFlushedBlock - e.lookbackPeriod
+			// start from lastFlushedBlock
+			start := e.lastFlushedBlock
 
 			logger.Info(fmt.Sprintf("Flush started from %d to %d", start, latestBlock))
 
+			// consume from lastFlushedBlock to the latestBlock
 			e.getAndConsumeHistory(ctx, logger, processingQueue, messageSent, messageTransmitterAddress, messageTransmitterABI, start, latestBlock)
 
+			// update lastFlushedBlock to the last block it flushed
 			e.lastFlushedBlock = latestBlock
 
 			logger.Info("Flush complete")


### PR DESCRIPTION
Closes #78 

Changes:
- Swaps `newHead` subscriptions to ETH based chains with periodic (every 30s) RPC queries for the chain's latest height.
- Removes overkill flushing. Previously the flushing mechanism would partially overlap the same range of blocks multiple times, increasing our request count and monthly bill simultaneously. This PR removes the overlap entirely. If the TX isn't picked up the first time naturally, nor the second time via a flush, something else has to be wrong.

Example of previous flushing overlap on Optimism:
```
Optimism: 900 block lookback period
Flush started from 118,630,819 to 118,632,023
Flush started from 118,631,123 to 118,632,327
Flush started from 118,631,427 to 118,632,632
Flush started from 118,631,732 to 118,632,936
```
As seen, the 2nd, 3rd, and 4th flush are all overlapping blocks covered by the first flush.