### PR TITLE
Code Refactoring and Cleanup

### DIFF
--- a/integration/deployed_relayer_test.go
+++ b/integration/deployed_relayer_test.go
@@ -161,7 +161,7 @@ func TestNobleBurnToEthDeployed(t *testing.T) {
 
 	rpcResponse, err := cc.RPCClient.BroadcastTxSync(context.Background(), txBytes)
 	require.Nil(t, err)
-	fmt.Printf("Deposit for Burn broadcasted: https://testnet.mintscan.io/noble-testnet/txs/%s\n", rpcResponse.Hash.String())
+	fmt.Printf("Deposit for Burn broadcasted: https://mintscan.io/noble-testnet/txs/%s\n", rpcResponse.Hash.String())
 
 	fmt.Println("Waiting for circle to approve and destination wallet to receive funds...")
 	var newEthBalance uint64

--- a/noble/listener.go
+++ b/noble/listener.go
@@ -89,8 +89,7 @@ func (n *Noble) StartListener(
 				select {
 				case <-ctx.Done():
 					return
-				default:
-					block := <-blockQueue
+				case block := <-blockQueue:
 					res, err := n.cc.RPCClient.TxSearch(ctx, fmt.Sprintf("tx.height=%d", block), false, nil, nil, "")
 					if err != nil || res == nil {
 						logger.Debug(fmt.Sprintf("Unable to query Noble block %d. Will retry.", block), "error:", err)


### PR DESCRIPTION
Closes #81 

- Refactors redundant, usually pertaining to timer logic within routines
- Fixes a URL link
- Fixes a blocking issue within a select statement

This project still needs some linting work, but that'll be for another PR.