### PR TITLE
feat: override private keys w/ env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,24 @@ By default, metrics are exported at on port :2112/metrics (`http://localhost:211
 | cctp_relayer_chain_latest_height    | Current height of the chain.                                                                                                                       | Gauge    |
 | cctp_relayer_broadcast_errors_total | The total number of failed broadcasts. Note: this is AFTER it retries `broadcast-retries` (config setting) number of times.                        | Counter  |
 
-### Noble Key
+### Minter Private Keys
+Minter private keys are required on a per chain basis to broadcast transactions to the target chain. These private keys can either be set in the `config.yaml` or via environment variables. 
 
-The noble private key you input into the config must be hex encoded. The easiest way to get this is via a chain binary:
+#### Config Private Keys
+
+Please see `./config/sample-config.yaml` for setting minter private keys in configuration. Please note that this method is insecure as the private keys are stored in plain text.
+
+#### Env Vars Private Keys
+
+To pass in a private key via an environment variable, first identify the chain's name. A chain's name corresponds to the key under the `chains` section in the `config.yaml`. The sample config lists these chain names for example: `noble`, `ethereum`, `optimism`, etc. Now, take the chain name in all caps and append `_PRIV_KEY`.
+
+An environment variable for `noble` would look like: `NOBLE_PRIV_KEY=<PRIVATE_KEY_HERE>`
+
+#### Noble Private Key Format
+
+The noble private key you input into the config or via enviroment variables must be hex encoded. The easiest way to get this is via a chain binary:
 
 `nobled keys export <KEY_NAME> --unarmored-hex --unsafe`
-
 
 ### API
 Simple API to query message state cache

--- a/ethereum/config.go
+++ b/ethereum/config.go
@@ -32,9 +32,10 @@ type ChainConfig struct {
 }
 
 func (c *ChainConfig) Chain(name string) (types.Chain, error) {
-	if len(c.MinterPrivateKey) == 0 {
-		envKey := strings.ToUpper(name) + "_PRIV_KEY"
-		privKey := os.Getenv(envKey)
+	envKey := strings.ToUpper(name) + "_PRIV_KEY"
+	privKey := os.Getenv(envKey)
+
+	if len(c.MinterPrivateKey) == 0 || len(privKey) != 0 {
 		if len(privKey) == 0 {
 			return nil, fmt.Errorf("env variable %s is empty, priv key not found for chain %s", envKey, name)
 		} else {

--- a/ethereum/config.go
+++ b/ethereum/config.go
@@ -1,6 +1,10 @@
 package ethereum
 
 import (
+	"fmt"
+	"os"
+	"strings"
+
 	"github.com/strangelove-ventures/noble-cctp-relayer/types"
 )
 
@@ -24,11 +28,20 @@ type ChainConfig struct {
 	MetricsDenom    string `yaml:"metrics-denom"`
 	MetricsExponent int    `yaml:"metrics-exponent"`
 
-	// TODO move to keyring
 	MinterPrivateKey string `yaml:"minter-private-key"`
 }
 
 func (c *ChainConfig) Chain(name string) (types.Chain, error) {
+	if len(c.MinterPrivateKey) == 0 {
+		envKey := strings.ToUpper(name) + "_PRIV_KEY"
+		privKey := os.Getenv(envKey)
+		if len(privKey) == 0 {
+			return nil, fmt.Errorf("env variable %s is empty, priv key not found for chain %s", envKey, name)
+		} else {
+			c.MinterPrivateKey = privKey
+		}
+	}
+
 	return NewChain(
 		name,
 		c.Domain,

--- a/noble/config.go
+++ b/noble/config.go
@@ -1,6 +1,12 @@
 package noble
 
-import "github.com/strangelove-ventures/noble-cctp-relayer/types"
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/strangelove-ventures/noble-cctp-relayer/types"
+)
 
 var _ types.ChainConfig = (*ChainConfig)(nil)
 
@@ -23,11 +29,20 @@ type ChainConfig struct {
 
 	MinMintAmount uint64 `yaml:"min-mint-amount"`
 
-	// TODO move to keyring
 	MinterPrivateKey string `yaml:"minter-private-key"`
 }
 
 func (c *ChainConfig) Chain(name string) (types.Chain, error) {
+	if len(c.MinterPrivateKey) == 0 {
+		envKey := strings.ToUpper(name) + "_PRIV_KEY"
+		privKey := os.Getenv(envKey)
+		if len(privKey) == 0 {
+			return nil, fmt.Errorf("env variable %s is empty, priv key not found for chain %s", envKey, name)
+		} else {
+			c.MinterPrivateKey = privKey
+		}
+	}
+
 	return NewChain(
 		c.RPC,
 		c.ChainID,

--- a/noble/config.go
+++ b/noble/config.go
@@ -33,9 +33,10 @@ type ChainConfig struct {
 }
 
 func (c *ChainConfig) Chain(name string) (types.Chain, error) {
-	if len(c.MinterPrivateKey) == 0 {
-		envKey := strings.ToUpper(name) + "_PRIV_KEY"
-		privKey := os.Getenv(envKey)
+	envKey := strings.ToUpper(name) + "_PRIV_KEY"
+	privKey := os.Getenv(envKey)
+
+	if len(c.MinterPrivateKey) == 0 || len(privKey) != 0 {
 		if len(privKey) == 0 {
 			return nil, fmt.Errorf("env variable %s is empty, priv key not found for chain %s", envKey, name)
 		} else {


### PR DESCRIPTION
Closes #85 

This PR allows private minter keys to be overridden / set with environment variables instead of the configuration file. This helps move us away from storing our private keys in plain text.

Note: Unfortunately I wasn't able to figure out a way to refactor the same logic into a utility function without making the code more confusing. I'll leave refactoring that for a future update. I do hope to make the logic between cosmos & eth based chains more consistent.