### PR TITLE
feat: flush only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Consider a 30 minute flush interval (1800 seconds)
 - Polygon: 2 second blocks = (1800 / 2) = `900 blocks`
 - Arbitrum: 0.26 second blocks = (1800 / 0.26) = `~6950 blocks`
 
+### Flush Only Mode
+
+This relayer also supports a `--flush-only-mode`. This mode will only flush the chain and not actively listen for new events as they occur. This is useful for running a secondary relayer which "lags" behind the primary relayer. It is only responsible for retrying failed transactions. 
+
+When the relayer is in flush only mode, the flush mechanism will start at `latest height - (4 * lookback period)` and finish at `latest height - (3 * lookback period)`. For all subsequent flushes, the relayer will start at the last flushed block and finish at `latest height - (3 * lookback period)`. Please see the notes above for configuring the flush interval and lookback period.
+
+> Note: It is highly recommended to use the same configuration for both the primary and secondary relayer. This ensures that there is zero overlap between the relayers.
+
 ### Prometheus Metrics
 
 By default, metrics are exported at on port :2112/metrics (`http://localhost:2112/metrics`). You can customize the port using the `--metrics-port` flag. 

--- a/circle/attestation.go
+++ b/circle/attestation.go
@@ -15,13 +15,6 @@ import (
 
 // CheckAttestation checks the iris api for attestation status and returns true if attestation is complete
 func CheckAttestation(attestationURL string, logger log.Logger, irisLookupID string, txHash string, sourceDomain, destDomain types.Domain) *types.AttestationResponse {
-	logger.Debug(fmt.Sprintf("Checking attestation for %s%s%s for source tx %s from %d to %d", attestationURL, "0x", irisLookupID, txHash, sourceDomain, destDomain))
-
-	client := http.Client{Timeout: 2 * time.Second}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
 	// append ending / if not present
 	if attestationURL[len(attestationURL)-1:] != "/" {
 		attestationURL += "/"
@@ -32,22 +25,30 @@ func CheckAttestation(attestationURL string, logger log.Logger, irisLookupID str
 		irisLookupID = "0x" + irisLookupID
 	}
 
+	logger.Debug(fmt.Sprintf("Checking attestation for %s%s for source tx %s from %d to %d", attestationURL, irisLookupID, txHash, sourceDomain, destDomain))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, attestationURL+irisLookupID, nil)
 	if err != nil {
 		logger.Debug("error creating request: " + err.Error())
 		return nil
 	}
 
+	client := http.Client{}
 	rawResponse, err := client.Do(req)
 	if err != nil {
 		logger.Debug("error during request: " + err.Error())
 		return nil
 	}
+
 	defer rawResponse.Body.Close()
 	if rawResponse.StatusCode != http.StatusOK {
 		logger.Debug("non 200 response received from Circles attestation API")
 		return nil
 	}
+
 	body, err := io.ReadAll(rawResponse.Body)
 	if err != nil {
 		logger.Debug("unable to parse message body")
@@ -60,7 +61,8 @@ func CheckAttestation(attestationURL string, logger log.Logger, irisLookupID str
 		logger.Debug("unable to unmarshal response")
 		return nil
 	}
-	logger.Info(fmt.Sprintf("Attestation found for %s%s%s", attestationURL, "0x", irisLookupID))
+
+	logger.Info(fmt.Sprintf("Attestation found for %s%s", attestationURL, irisLookupID))
 
 	return &response
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -13,6 +13,7 @@ const (
 	flagJSON          = "json"
 	flagMetricsPort   = "metrics-port"
 	flagFlushInterval = "flush-interval"
+	flagFlushOnlyMode = "flush-only-mode"
 )
 
 func addAppPersistantFlags(cmd *cobra.Command, a *AppState) *cobra.Command {
@@ -21,6 +22,7 @@ func addAppPersistantFlags(cmd *cobra.Command, a *AppState) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&a.LogLevel, flagLogLevel, "info", "log level (debug, info, warn, error)")
 	cmd.PersistentFlags().Int16P(flagMetricsPort, "p", 2112, "customize Prometheus metrics port")
 	cmd.PersistentFlags().DurationP(flagFlushInterval, "i", 0, "how frequently should a flush routine be run")
+	cmd.PersistentFlags().BoolP(flagFlushOnlyMode, "f", false, "only run the background flush routine (acts as a redundant relayer)")
 	return cmd
 }
 

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -49,7 +49,7 @@ func Start(a *AppState) *cobra.Command {
 
 			flushOnly, err := cmd.Flags().GetBool(flagFlushOnlyMode)
 			if err != nil {
-				return fmt.Errorf("invalid flush only flag error=%e", err)
+				return fmt.Errorf("invalid flush only flag error=%w", err)
 			}
 
 			if flushInterval == 0 {
@@ -70,7 +70,7 @@ func Start(a *AppState) *cobra.Command {
 
 			port, err := cmd.Flags().GetInt16(flagMetricsPort)
 			if err != nil {
-				return fmt.Errorf("invalid port error=%e", err)
+				return fmt.Errorf("invalid port error=%w", err)
 			}
 
 			metrics := relayer.InitPromMetrics(port)
@@ -78,13 +78,13 @@ func Start(a *AppState) *cobra.Command {
 			for name, cfg := range cfg.Chains {
 				c, err := cfg.Chain(name)
 				if err != nil {
-					return fmt.Errorf("error creating chain error=%e", err)
+					return fmt.Errorf("error creating chain error=%w", err)
 				}
 
 				logger = logger.With("name", c.Name(), "domain", c.Domain())
 
 				if err := c.InitializeClients(cmd.Context(), logger); err != nil {
-					return fmt.Errorf("error initializing client error=%e", err)
+					return fmt.Errorf("error initializing client error=%w", err)
 				}
 
 				go c.TrackLatestBlockHeight(cmd.Context(), logger, metrics)
@@ -103,7 +103,7 @@ func Start(a *AppState) *cobra.Command {
 				}
 
 				if err := c.InitializeBroadcaster(cmd.Context(), logger, sequenceMap); err != nil {
-					return fmt.Errorf("error initializing broadcaster error=%e", err)
+					return fmt.Errorf("error initializing broadcaster error=%w", err)
 				}
 
 				go c.StartListener(cmd.Context(), logger, processingQueue, flushOnly, flushInterval)

--- a/ethereum/listener.go
+++ b/ethereum/listener.go
@@ -56,8 +56,7 @@ func (e *Ethereum) StartListener(
 		Ready: make(chan struct{}),
 	}
 
-	// FlushOnlyMode should only run the flush mechanism, otherwise start the main listener,
-	// otherwise consume history and incoming msgs
+	// FlushOnlyMode is used for the secondary, flush only relayer. When enabled, the main stream is not started.
 	if flushOnlyMode {
 		go e.flushMechanism(ctx, logger, processingQueue, messageSent, messageTransmitterAddress, messageTransmitterABI, flushOnlyMode, flushInterval, sig)
 	} else {

--- a/ethereum/listener_test.go
+++ b/ethereum/listener_test.go
@@ -28,7 +28,7 @@ func TestStartListener(t *testing.T) {
 
 	processingQueue := make(chan *types.TxState, 10000)
 
-	go eth.StartListener(ctx, a.Logger, processingQueue, 0)
+	go eth.StartListener(ctx, a.Logger, processingQueue, false, 0)
 
 	time.Sleep(5 * time.Second)
 

--- a/integration/eth_burn_to_noble_mint_test.go
+++ b/integration/eth_burn_to_noble_mint_test.go
@@ -73,7 +73,7 @@ func TestEthBurnToNobleMint(t *testing.T) {
 
 	processingQueue := make(chan *types.TxState, 10)
 
-	go ethChain.StartListener(ctx, a.Logger, processingQueue, 0)
+	go ethChain.StartListener(ctx, a.Logger, processingQueue, false, 0)
 	go cmd.StartProcessor(ctx, a, registeredDomains, processingQueue, sequenceMap, nil)
 
 	_, _, generatedWallet := testdata.KeyTestPubAddr()

--- a/integration/noble_burn_to_eth_mint_test.go
+++ b/integration/noble_burn_to_eth_mint_test.go
@@ -79,7 +79,7 @@ func TestNobleBurnToEthMint(t *testing.T) {
 
 	processingQueue := make(chan *types.TxState, 10)
 
-	go nobleChain.StartListener(ctx, a.Logger, processingQueue, 0)
+	go nobleChain.StartListener(ctx, a.Logger, processingQueue, false, 0)
 	go cmd.StartProcessor(ctx, a, registeredDomains, processingQueue, sequenceMap, nil)
 
 	ethDestinationAddress, _, err := generateEthWallet()

--- a/noble/listener_test.go
+++ b/noble/listener_test.go
@@ -27,7 +27,7 @@ func TestStartListener(t *testing.T) {
 
 	processingQueue := make(chan *types.TxState, 10000)
 
-	go n.StartListener(ctx, a.Logger, processingQueue, 0)
+	go n.StartListener(ctx, a.Logger, processingQueue, false, 0)
 
 	time.Sleep(20 * time.Second)
 

--- a/types/chain.go
+++ b/types/chain.go
@@ -53,6 +53,7 @@ type Chain interface {
 		ctx context.Context,
 		logger log.Logger,
 		processingQueue chan *TxState,
+		flushOnlyMode bool,
 		flushInterval time.Duration,
 	)
 


### PR DESCRIPTION
Closes #67 

This flush only mode is for running redundant secondary relayers. This mode will not have active listeners for each chain, but rather it will "lag" behind the primary relayer and double check transactions to ensure nothing was missed. Please see the updated README for configuration and implementation.