### PR TITLE
feat: customize metrics address

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -21,7 +21,7 @@ func addAppPersistantFlags(cmd *cobra.Command, a *AppState) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&a.ConfigPath, flagConfigPath, defaultConfigPath, "file path of config file")
 	cmd.PersistentFlags().BoolVarP(&a.Debug, flagVerbose, "v", false, fmt.Sprintf("use this flag to set log level to `debug` (overrides %s flag)", flagLogLevel))
 	cmd.PersistentFlags().StringVar(&a.LogLevel, flagLogLevel, "info", "log level (debug, info, warn, error)")
-	cmd.PersistentFlags().String(flagMetricsAddress, "localhost", "customize Prometheus metrics host address, this can be used in conjunction with `metrics-port` to adjust entire endpoint")
+	cmd.PersistentFlags().String(flagMetricsAddress, "localhost", "customize Prometheus metrics address, this can be used in conjunction with `metrics-port` to adjust the entire endpoint")
 	cmd.PersistentFlags().Int16P(flagMetricsPort, "p", 2112, "customize Prometheus metrics port")
 	cmd.PersistentFlags().DurationP(flagFlushInterval, "i", 0, "how frequently should a flush routine be run")
 	cmd.PersistentFlags().BoolP(flagFlushOnlyMode, "f", false, "only run the background flush routine (acts as a redundant relayer)")

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -7,19 +7,21 @@ import (
 )
 
 const (
-	flagConfigPath    = "config"
-	flagVerbose       = "verbose"
-	flagLogLevel      = "log-level"
-	flagJSON          = "json"
-	flagMetricsPort   = "metrics-port"
-	flagFlushInterval = "flush-interval"
-	flagFlushOnlyMode = "flush-only-mode"
+	flagConfigPath     = "config"
+	flagVerbose        = "verbose"
+	flagLogLevel       = "log-level"
+	flagJSON           = "json"
+	flagMetricsAddress = "metrics-address"
+	flagMetricsPort    = "metrics-port"
+	flagFlushInterval  = "flush-interval"
+	flagFlushOnlyMode  = "flush-only-mode"
 )
 
 func addAppPersistantFlags(cmd *cobra.Command, a *AppState) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&a.ConfigPath, flagConfigPath, defaultConfigPath, "file path of config file")
 	cmd.PersistentFlags().BoolVarP(&a.Debug, flagVerbose, "v", false, fmt.Sprintf("use this flag to set log level to `debug` (overrides %s flag)", flagLogLevel))
 	cmd.PersistentFlags().StringVar(&a.LogLevel, flagLogLevel, "info", "log level (debug, info, warn, error)")
+	cmd.PersistentFlags().String(flagMetricsAddress, "localhost", "customize Prometheus metrics host address, this can be used in conjunction with `metrics-port` to adjust entire endpoint")
 	cmd.PersistentFlags().Int16P(flagMetricsPort, "p", 2112, "customize Prometheus metrics port")
 	cmd.PersistentFlags().DurationP(flagFlushInterval, "i", 0, "how frequently should a flush routine be run")
 	cmd.PersistentFlags().BoolP(flagFlushOnlyMode, "f", false, "only run the background flush routine (acts as a redundant relayer)")

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -73,7 +73,12 @@ func Start(a *AppState) *cobra.Command {
 				return fmt.Errorf("invalid port error=%w", err)
 			}
 
-			metrics := relayer.InitPromMetrics(port)
+			address, err := cmd.Flags().GetString(flagMetricsAddress)
+			if err != nil {
+				return fmt.Errorf("invalid address error=%w", err)
+			}
+
+			metrics := relayer.InitPromMetrics(address, port)
 
 			for name, cfg := range cfg.Chains {
 				c, err := cfg.Chain(name)

--- a/relayer/metrics.go
+++ b/relayer/metrics.go
@@ -16,7 +16,7 @@ type PromMetrics struct {
 	BroadcastErrors *prometheus.CounterVec
 }
 
-func InitPromMetrics(port int16) *PromMetrics {
+func InitPromMetrics(address string, port int16) *PromMetrics {
 	reg := prometheus.NewRegistry()
 
 	// labels
@@ -49,7 +49,7 @@ func InitPromMetrics(port int16) *PromMetrics {
 	go func() {
 		http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg}))
 		server := &http.Server{
-			Addr:        fmt.Sprintf(":%d", port),
+			Addr:        fmt.Sprintf("%s:%d", address, port),
 			ReadTimeout: 3 * time.Second,
 		}
 		log.Fatal(server.ListenAndServe())


### PR DESCRIPTION
Currently, the relayer exposes metrics on `localhost`.
This does not allow for external Prometheus instances to scrape metrics.

This PR adds the `metrics-address` flag. 
Users will now be able to change `localhost` to `0.0.0.0` to allow external scraping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new command-line flag to customize the host address for Prometheus metrics, allowing users to specify both the address and port for the metrics endpoint.

- **Enhancements**
  - The metrics endpoint can now be bound to a specific network interface, providing greater flexibility in configuring how Prometheus metrics are exposed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->